### PR TITLE
Add CBOR encoder / decoder for internal MkPayment representation

### DIFF
--- a/cardano-transactions.cabal
+++ b/cardano-transactions.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4334c2d2a2078b5a3194e595958443cbb0463f3406afc7da0c9434953ff19f78
+-- hash: 22964f0c7629eae3f0be0146535605a2db4e3340b9039e907470f34d5c5eb8c4
 
 name:           cardano-transactions
 version:        1.0.0
@@ -66,8 +66,10 @@ test-suite unit
     , cardano-crypto
     , cardano-crypto-wrapper
     , cardano-ledger
+    , cardano-ledger-test
     , cardano-transactions
     , cborg
+    , hedgehog-quickcheck
     , hspec
     , text
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -65,8 +65,10 @@ tests:
     - cardano-crypto
     - cardano-crypto-wrapper
     - cardano-ledger
+    - cardano-ledger-test
     - cardano-transactions
     - cborg
+    - hedgehog-quickcheck
     - hspec
     - QuickCheck
     - text

--- a/src/Data/UTxO/Transaction.hs
+++ b/src/Data/UTxO/Transaction.hs
@@ -125,7 +125,7 @@ data ErrMkPayment
         -- ^ Payments must have at least one output
     | MissingSignature
         -- ^ Payments must have a signature for each input.
-    deriving (Show, Eq)
+    deriving (Show, Read, Eq)
 
 -- $note
 --

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,27 +8,50 @@ packages:
 - .
 
 extra-deps:
+  - hedgehog-quickcheck-0.1.1
+
   - git: https://github.com/input-output-hk/cardano-ledger #
     commit: 512c26a66a6a63278846646b81bf8eadcd4ae99c       #
     subdirs:                                               #
       - cardano-ledger                                     #
+      - cardano-ledger/test                                #
       - crypto                                             #
+      - crypto/test                                        #
                                                            #
   # required by cardano-ledger --------------------------- #
   - canonical-json-0.6.0.0
   - base58-bytestring-0.1.0
+  - generic-monoid-0.1.0.0
+  - gray-code-0.3.1
+  - moo-1.2
   - streaming-binary-0.3.0.1
-
-  - git: https://github.com/input-output-hk/cardano-crypto
-    commit: 05aa1bc640c42bfca787531d12595489c1fa3b82
-
-  - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
+  - Unique-0.4.7.6
 
   - git: https://github.com/input-output-hk/cardano-base
     commit: 1222078176fe74d5ce17f2a8343c6588233a49a3
     subdirs:
       - binary
+      - binary/test
+      - cardano-crypto-class
+
+  - git: https://github.com/input-output-hk/cardano-crypto
+    commit: 05aa1bc640c42bfca787531d12595489c1fa3b82
+
+  - git: https://github.com/input-output-hk/cardano-ledger-specs
+    commit: 647cd71e3c4630488e71596f5e9c26fee598b541
+    subdirs:
+      - byron/semantics/executable-spec # small-steps
+      - byron/ledger/executable-spec    # cs-ledger
+      - byron/chain/executable-spec     # cs-blockchain
+
+  - git: https://github.com/input-output-hk/cardano-prelude
+    commit: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
+    subdirs:
+      - .
+      - test
+
+  - git: https://github.com/input-output-hk/goblins
+    commit: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
     commit: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9


### PR DESCRIPTION
The goal is to then enable the command-line interface, using this underlying representation. 
With this, we can have a command-line printing on stdout an intermediate encoded representation that can be easily piped between commands (very much like jcli): 

```
$  cardano-tx empty --mainnet \
    | cardano-tx add-input 14 3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7 \
    | cardano-tx add-output 42 Ae2tdPwUPEZETXfbQxKMkMJQY1MoHCBS7bkw6TmhLjRvi9LZh1uDnXy319f \
    | cardano-tx lock \
    | cardano-tx signWith e0860dab46f13e74ab834142e8877b80bf22044cae8ebab7a21ed1b8dc00c155 \
    | cardano-tx serialize
```