### PR TITLE
Command-line for constructing transaction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,16 @@ jobs:
     - name: Setup Stack
       uses: mstksg/setup-stack@v1
 
+    - name: Cache Key
+      id: cache_key
+      run: echo ::set-output name=key::$(md5sum stack.yaml | awk '{print $1}')
+
     - name: Cache Dependencies
       id: cache
       uses: actions/cache@v1
       with:
         path: ~/.stack
-        key: ${{ matrix.os }}-stack
+        key: ${{ matrix.os }}-${{ steps.cache_key.outputs.key }}
 
     - name: Build Snapshot
       if: steps.cache.outputs.cache-hit != 'true'

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,0 +1,383 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Main where
+
+import Prelude
+
+import Control.Exception
+    ( bracket )
+import Control.Monad
+    ( guard, void )
+import Data.ByteArray.Encoding
+    ( Base (..), convertFromBase, convertToBase )
+import Data.ByteString
+    ( ByteString )
+import Data.Maybe
+    ( isNothing )
+import Data.Text
+    ( Text )
+import Data.UTxO.Transaction
+    ( MkPayment (..) )
+import Data.UTxO.Transaction.Cardano.Byron
+    ( Byron
+    , decodeCoinSel
+    , decodeTx
+    , encodeCoinSel
+    , encodeTx
+    , fromBase16
+    , fromBase58
+    , mkInit
+    , mkInput
+    , mkOutput
+    , mkSignKey
+    )
+import Data.Word
+    ( Word32 )
+import Numeric.Natural
+    ( Natural )
+import Options.Applicative
+    ( ArgumentFields
+    , CommandFields
+    , Mod
+    , Parser
+    , ParserInfo
+    , argument
+    , auto
+    , command
+    , customExecParser
+    , footerDoc
+    , header
+    , headerDoc
+    , helper
+    , info
+    , maybeReader
+    , metavar
+    , prefs
+    , progDesc
+    , showHelpOnEmpty
+    , subparser
+    )
+import Options.Applicative.Help.Pretty
+    ( indent, string, vsep )
+import System.Console.ANSI
+    ( Color (..)
+    , ColorIntensity (..)
+    , ConsoleLayer (..)
+    , SGR (..)
+    , hSetSGR
+    , hSupportsANSIWithoutEmulation
+    )
+import System.Exit
+    ( exitFailure )
+import System.IO
+    ( Handle, hIsTerminalDevice, stderr, stdin, stdout )
+
+import qualified Codec.CBOR.Decoding as CBOR
+import qualified Codec.CBOR.Encoding as CBOR
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Write as CBOR
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.Text.IO as TIO
+import qualified Data.UTxO.Transaction as Tx
+
+
+main :: IO ()
+main = setup >> parseCmd >>= \case
+    CmdEmpty Empty{protocolMagic} -> do
+        let state0 = Tx.empty protocolMagic
+        hPutState stdout (encodeCoinSel state0)
+
+    CmdAddInput AddInput{inputIx,inputTxId} -> do
+        state <- hGetState stdin decodeCoinSel
+        case mkInput inputIx inputTxId of
+            Nothing -> failWith "Invalid input index or transaction id."
+            Just input -> do
+                let state' = Tx.addInput input state
+                hPutState stdout (encodeCoinSel state')
+
+    CmdAddOutput AddOutput{coin,address} -> do
+        state <- hGetState stdin decodeCoinSel
+        case mkOutput coin address of
+            Nothing -> failWith "Invalid output value or address."
+            Just output -> do
+                let state' = Tx.addOutput output state
+                hPutState stdout (encodeCoinSel state')
+
+    CmdLock -> do
+        state <- hGetState stdin decodeCoinSel
+        let state' = Tx.lock state
+        hPutState stdout (encodeTx state')
+
+    CmdSignWith SignWith{prvKey} -> do
+        state <- hGetState stdin decodeTx
+        case mkSignKey prvKey of
+            Nothing -> failWith "Invalid signing key."
+            Just signKey -> do
+                let state' = Tx.signWith signKey state
+                hPutState stdout (encodeTx state')
+
+    CmdSerialize -> do
+        state <- hGetState stdin decodeTx
+        case Tx.serialize state of
+            Left e -> failWith (show e)
+            Right bytes -> TIO.putStr (base64 bytes)
+  where
+    setup :: IO ()
+    setup = do
+        -- Enable ANSI colors on Windows.
+        void $ hSupportsANSIWithoutEmulation stderr
+
+parseCmd :: IO Cmd
+parseCmd = customExecParser (prefs showHelpOnEmpty) cmd
+
+data Cmd
+    = CmdEmpty Empty
+    | CmdAddInput AddInput
+    | CmdAddOutput AddOutput
+    | CmdLock
+    | CmdSignWith SignWith
+    | CmdSerialize
+    deriving (Show)
+
+cmd :: ParserInfo Cmd
+cmd = info (helper <*> cmds) $ progDesc "cardano-tx"
+  where
+    cmds = subparser $ mconcat
+        [ cmdEmpty
+        , cmdAddInput
+        , cmdAddOutput
+        , cmdLock
+        , cmdSignWith
+        , cmdSerialize
+        ]
+
+--                       _
+--                      | |
+--   ___ _ __ ___  _ __ | |_ _   _
+--  / _ \ '_ ` _ \| '_ \| __| | | |
+-- |  __/ | | | | | |_) | |_| |_| |
+--  \___|_| |_| |_| .__/ \__|\__, |
+--                | |         __/ |
+--                |_|        |___/
+
+newtype Empty = Empty
+    { protocolMagic :: Init Byron
+    } deriving (Show)
+
+cmdEmpty :: Mod CommandFields Cmd
+cmdEmpty = command "empty" $
+    info (helper <*> fmap CmdEmpty subCmd) mempty
+  where
+    subCmd = Empty <$> protocolMagicArg
+
+protocolMagicArg :: Parser (Init Byron)
+protocolMagicArg = fmap mkInit $ argument auto $
+    metavar "PROTOCOL MAGIC"
+
+--            _     _        _                   _
+--           | |   | |      (_)                 | |
+--   __ _  __| | __| |______ _ _ __  _ __  _   _| |_
+--  / _` |/ _` |/ _` |______| | '_ \| '_ \| | | | __|
+-- | (_| | (_| | (_| |      | | | | | |_) | |_| | |_
+--  \__,_|\__,_|\__,_|      |_|_| |_| .__/ \__,_|\__|
+--                                  | |
+--                                  |_|
+
+data AddInput = AddInput
+    { inputIx :: Word32
+    , inputTxId :: ByteString
+    } deriving (Show)
+
+cmdAddInput :: Mod CommandFields Cmd
+cmdAddInput = command "add-input" $
+    info (helper <*> fmap CmdAddInput subCmd) $ mconcat
+        [ progDesc "Add a new input to the transaction."
+        , headerDoc (Just $ vsep
+            [ string "An input is made of:"
+            , indent 2 $ string "- A input index."
+            , indent 2 $ string "- An transaction id, 32 bytes, base16-encoded."
+            ])
+        , footerDoc (Just $ vsep
+            [ string "Example:"
+            , indent 2 $ string "add-input 0 3b40265...aad1c0b7"
+            , indent 2 $ string "            <--- 64 CHARS --->"
+            ])
+        ]
+  where
+    subCmd = AddInput <$> inputIxArg <*> inputTxIdArg
+
+inputIxArg :: Parser Word32
+inputIxArg = argument auto $
+    metavar "INDEX"
+
+inputTxIdArg :: Parser ByteString
+inputTxIdArg = bytesArgument (Just 32) fromBase16 $
+    metavar "TXID"
+
+--            _     _                   _               _
+--           | |   | |                 | |             | |
+--   __ _  __| | __| |______ ___  _   _| |_ _ __  _   _| |_
+--  / _` |/ _` |/ _` |______/ _ \| | | | __| '_ \| | | | __|
+-- | (_| | (_| | (_| |     | (_) | |_| | |_| |_) | |_| | |_
+--  \__,_|\__,_|\__,_|      \___/ \__,_|\__| .__/ \__,_|\__|
+--                                         | |
+--                                         |_|
+
+data AddOutput = AddOutput
+    { coin :: Natural
+    , address :: ByteString
+    } deriving (Show)
+
+cmdAddOutput :: Mod CommandFields Cmd
+cmdAddOutput = command "add-output" $
+    info (helper <*> fmap CmdAddOutput subCmd) $ mconcat
+        [ progDesc "Add a new output to the transaction."
+        , headerDoc (Just $ vsep
+            [ string "An output is made of:"
+            , indent 2 $ string "- A coin value in Lovelace (1 Ada = 1e6 Lovelace)."
+            , indent 2 $ string "- A target address, base58-encoded."
+            ])
+        , footerDoc (Just $ vsep
+            [ string "Example:"
+            , indent 2 $ string "add-output 1000000 2cWKMJemo...ZTBMqHTPTkv"
+            ])
+        ]
+  where
+    subCmd = AddOutput <$> coinArg <*> addressArg
+
+coinArg :: Parser Natural
+coinArg = argument auto $
+    metavar "LOVELACE"
+
+addressArg :: Parser ByteString
+addressArg = bytesArgument Nothing fromBase58 $
+    metavar "ADDRESS"
+
+--  _            _
+-- | |          | |
+-- | | ___   ___| | __
+-- | |/ _ \ / __| |/ /
+-- | | (_) | (__|   <
+-- |_|\___/ \___|_|\_\
+
+cmdLock :: Mod CommandFields Cmd
+cmdLock = command "lock" $
+    info (helper <*> pure CmdLock) $ mconcat
+        [ progDesc "Lock the transaction and start signing inputs."
+        , header
+            "Once locked, it is no longer possible to add inputs or outputs to \
+            \a transaction. This is a necessary step to be able to sign the \
+            \transaction with private keys corresponding to inputs."
+        ]
+
+--      _             _    _ _ _   _
+--     (_)           | |  | (_) | | |
+--  ___ _  __ _ _ __ | |  | |_| |_| |__
+-- / __| |/ _` | '_ \| |/\| | | __| '_ \
+-- \__ \ | (_| | | | \  /\  / | |_| | | |
+-- |___/_|\__, |_| |_|\/  \/|_|\__|_| |_|
+--         __/ |
+--        |___/
+
+newtype SignWith = SignWith
+    { prvKey :: ByteString
+    } deriving (Show)
+
+cmdSignWith :: Mod CommandFields Cmd
+cmdSignWith = command "sign-with" $
+    info (helper <*> fmap CmdSignWith subCmd) $ mconcat
+        [ progDesc "Add a signature."
+        ]
+  where
+    subCmd = SignWith <$> prvKeyArg
+
+prvKeyArg :: Parser ByteString
+prvKeyArg = bytesArgument (Just 96) fromBase16 $
+    metavar "XPRV"
+
+--                _       _ _
+--               (_)     | (_)
+--  ___  ___ _ __ _  __ _| |_ _______
+-- / __|/ _ \ '__| |/ _` | | |_  / _ \
+-- \__ \  __/ |  | | (_| | | |/ /  __/
+-- |___/\___|_|  |_|\__,_|_|_/___\___|
+--
+
+cmdSerialize :: Mod CommandFields Cmd
+cmdSerialize = command "serialize" $
+    info (helper <*> pure CmdSerialize) $ mconcat
+        [ progDesc "Serialize the signed transaction to binary."
+        ]
+
+--  _   _      _
+-- | | | |    | |
+-- | |_| | ___| |_ __   ___ _ __ ___
+-- |  _  |/ _ \ | '_ \ / _ \ '__/ __|
+-- | | | |  __/ | |_) |  __/ |  \__ \
+-- \_| |_/\___|_| .__/ \___|_|  |___/
+--              | |
+--              |_|
+
+-- | Parse a encoded 'Bytestring' argument.
+bytesArgument
+    :: Maybe Int -- ^ Number of bytes that are expected, if known.
+    -> (Text -> Maybe ByteString) -- ^ A base conversion
+    -> Mod ArgumentFields ByteString
+    -> Parser ByteString
+bytesArgument len fromBase =
+    argument (maybeReader readerT)
+  where
+    readerT :: String -> Maybe ByteString
+    readerT str = do
+        bytes <- fromBase $ T.pack str
+        guard (isNothing len || Just (BS.length bytes) == len)
+        pure bytes
+
+-- | Convert a 'ByteString' to 'Base64'
+base64 :: ByteString -> Text
+base64 = T.decodeUtf8 . convertToBase Base64
+
+-- | Convert a /Base64/ 'Text' into a 'ByteString'
+fromBase64 :: Text -> Maybe ByteString
+fromBase64 = either (const Nothing) Just . convertFromBase Base64 . T.encodeUtf8
+
+-- | Deserialize data from a /Base64/ CBOR 'ByteString', or fail.
+hGetState :: Handle -> (forall s. CBOR.Decoder s a) -> IO a
+hGetState h decoder = do
+    bytes <- fromBase64 . T.decodeUtf8 <$> BS.hGetContents h
+    case bytes of
+        Nothing -> failWith
+            "Unable to decode intermediate buffer. Did you manually crafted one?"
+        Just cbor -> case CBOR.deserialiseFromBytes decoder (BL.fromStrict cbor) of
+            Left e -> failWith (show e)
+            Right (_, a) -> pure a
+
+-- | Helper to output a given state to the console
+hPutState :: Handle -> CBOR.Encoding -> IO ()
+hPutState h = TIO.hPutStr h . base64 . CBOR.toStrictByteString
+
+-- | Fail with a colored red error message.
+failWith :: String -> IO a
+failWith msg = do
+    withSGR stderr (SetColor Foreground Vivid Red) $ do
+        TIO.hPutStrLn stderr (T.pack msg)
+    exitFailure
+
+-- | Bracket-style constructor for applying ANSI Select Graphic Rendition to an
+-- action and revert back to normal after.
+--
+-- This does nothing if the device isn't an ANSI terminal.
+withSGR :: Handle -> SGR -> IO a -> IO a
+withSGR h sgr action = hIsTerminalDevice h >>= \case
+    True  -> bracket aFirst aLast aBetween
+    False -> action
+  where
+    aFirst = ([] <$ hSetSGR h [sgr])
+    aLast = hSetSGR h
+    aBetween = const action

--- a/cardano-transactions.cabal
+++ b/cardano-transactions.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 22964f0c7629eae3f0be0146535605a2db4e3340b9039e907470f34d5c5eb8c4
+-- hash: 4e1c168cdcb3ea0d1727505befb4fcdd66dc7a74a244e5950fa98173ff30cef9
 
 name:           cardano-transactions
 version:        1.0.0
@@ -47,6 +47,27 @@ library
     , cborg
     , cryptonite
     , memory
+    , text
+  default-language: Haskell2010
+
+executable cardano-tx
+  main-is: Main.hs
+  other-modules:
+      Paths_cardano_transactions
+  hs-source-dirs:
+      app
+  ghc-options: -Werror -Wall -Wcompat -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      ansi-terminal
+    , base >=4.7 && <5
+    , base58-bytestring
+    , bytestring
+    , cardano-binary
+    , cardano-crypto-wrapper
+    , cardano-transactions
+    , cborg
+    , memory
+    , optparse-applicative
     , text
   default-language: Haskell2010
 

--- a/cardano-transactions.cabal
+++ b/cardano-transactions.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: de2a733f765ac5a9ba38a7d954441eef0ce73855a42268e03ccc735406e88561
+-- hash: 533f6e12a95876d3acb529db2275e8a7074c207dcaf0f5b868d76b22d099351a
 
 name:           cardano-transactions
 version:        1.0.0
@@ -60,10 +60,7 @@ executable cardano-tx
   build-depends:
       ansi-terminal
     , base >=4.7 && <5
-    , base58-bytestring
     , bytestring
-    , cardano-binary
-    , cardano-crypto-wrapper
     , cardano-transactions
     , cborg
     , memory
@@ -79,14 +76,13 @@ test-suite unit
       Paths_cardano_transactions
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Werror -Wall -Wcompat -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-tools:
       cardano-tx
   build-depends:
       QuickCheck
     , base >=4.7 && <5
     , bytestring
-    , cardano-crypto
     , cardano-crypto-wrapper
     , cardano-ledger
     , cardano-ledger-test
@@ -94,7 +90,6 @@ test-suite unit
     , cborg
     , hedgehog-quickcheck
     , hspec
-    , memory
     , process
     , text
   default-language: Haskell2010

--- a/cardano-transactions.cabal
+++ b/cardano-transactions.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4e1c168cdcb3ea0d1727505befb4fcdd66dc7a74a244e5950fa98173ff30cef9
+-- hash: de2a733f765ac5a9ba38a7d954441eef0ce73855a42268e03ccc735406e88561
 
 name:           cardano-transactions
 version:        1.0.0
@@ -79,7 +79,9 @@ test-suite unit
       Paths_cardano_transactions
   hs-source-dirs:
       test
-  ghc-options: -Werror -Wall -Wcompat -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -fwarn-redundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  build-tools:
+      cardano-tx
   build-depends:
       QuickCheck
     , base >=4.7 && <5
@@ -92,5 +94,7 @@ test-suite unit
     , cborg
     , hedgehog-quickcheck
     , hspec
+    , memory
+    , process
     , text
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -37,16 +37,29 @@ library:
   - memory
   - text
 
-# executables:
-#   cardano-transactions-exe:
-#     main:                Main.hs
-#     source-dirs:         app
-#     ghc-options:
-#     - -threaded
-#     - -rtsopts
-#     - -with-rtsopts=-N
-#     dependencies:
-#     - cardano-transactions
+executables:
+  cardano-tx:
+    main: Main.hs
+    source-dirs: app
+    ghc-options:
+    - -Werror
+    - -Wall
+    - -Wcompat
+    - -fwarn-redundant-constraints
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - ansi-terminal
+    - base58-bytestring
+    - bytestring
+    - cardano-binary
+    - cardano-transactions
+    - cardano-crypto-wrapper
+    - cborg
+    - memory
+    - optparse-applicative
+    - text
 
 tests:
   unit:
@@ -72,4 +85,3 @@ tests:
     - hspec
     - QuickCheck
     - text
-

--- a/package.yaml
+++ b/package.yaml
@@ -66,7 +66,7 @@ tests:
     source-dirs: test
     main: Main.hs
     ghc-options:
-    - -Werror
+      #    - -Werror
     - -Wall
     - -Wcompat
     - -fwarn-redundant-constraints
@@ -83,5 +83,9 @@ tests:
     - cborg
     - hedgehog-quickcheck
     - hspec
+    - memory
+    - process
     - QuickCheck
     - text
+    build-tools:
+      cardano-tx

--- a/package.yaml
+++ b/package.yaml
@@ -51,11 +51,8 @@ executables:
     - -with-rtsopts=-N
     dependencies:
     - ansi-terminal
-    - base58-bytestring
     - bytestring
-    - cardano-binary
     - cardano-transactions
-    - cardano-crypto-wrapper
     - cborg
     - memory
     - optparse-applicative
@@ -66,7 +63,7 @@ tests:
     source-dirs: test
     main: Main.hs
     ghc-options:
-      #    - -Werror
+    - -Werror
     - -Wall
     - -Wcompat
     - -fwarn-redundant-constraints
@@ -75,7 +72,6 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - bytestring
-    - cardano-crypto
     - cardano-crypto-wrapper
     - cardano-ledger
     - cardano-ledger-test
@@ -83,7 +79,6 @@ tests:
     - cborg
     - hedgehog-quickcheck
     - hspec
-    - memory
     - process
     - QuickCheck
     - text

--- a/src/Data/UTxO/Transaction/Cardano/Byron.hs
+++ b/src/Data/UTxO/Transaction/Cardano/Byron.hs
@@ -22,6 +22,7 @@ module Data.UTxO.Transaction.Cardano.Byron
     -- * Converting From Bases
     , fromBase16
     , fromBase58
+    , fromBase64
 
     -- Internal
     , Byron
@@ -195,6 +196,13 @@ fromBase16 = either (const Nothing) Just . convertFromBase Base16 . T.encodeUtf8
 -- @since 1.0.0
 fromBase58 :: Text -> Maybe ByteString
 fromBase58 = decodeBase58 bitcoinAlphabet . T.encodeUtf8
+
+
+-- | Convert a base64 encoded 'Text' into a raw 'ByteString'
+--
+-- @since 1.0.0
+fromBase64 :: Text -> Maybe ByteString
+fromBase64 = either (const Nothing) Just . convertFromBase Base64 . T.encodeUtf8
 
 --
 -- MkPayment instance

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.25
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/master/snapshots/cardano-1.9.3.yaml
 
 # Generate files required by Weeder.
 # See https://github.com/ndmitchell/weeder/issues/53
@@ -9,52 +9,3 @@ packages:
 
 extra-deps:
   - hedgehog-quickcheck-0.1.1
-
-  - git: https://github.com/input-output-hk/cardano-ledger #
-    commit: 512c26a66a6a63278846646b81bf8eadcd4ae99c       #
-    subdirs:                                               #
-      - cardano-ledger                                     #
-      - cardano-ledger/test                                #
-      - crypto                                             #
-      - crypto/test                                        #
-                                                           #
-  # required by cardano-ledger --------------------------- #
-  - canonical-json-0.6.0.0
-  - base58-bytestring-0.1.0
-  - generic-monoid-0.1.0.0
-  - gray-code-0.3.1
-  - moo-1.2
-  - streaming-binary-0.3.0.1
-  - Unique-0.4.7.6
-
-  - git: https://github.com/input-output-hk/cardano-base
-    commit: 1222078176fe74d5ce17f2a8343c6588233a49a3
-    subdirs:
-      - binary
-      - binary/test
-      - cardano-crypto-class
-
-  - git: https://github.com/input-output-hk/cardano-crypto
-    commit: 05aa1bc640c42bfca787531d12595489c1fa3b82
-
-  - git: https://github.com/input-output-hk/cardano-ledger-specs
-    commit: 647cd71e3c4630488e71596f5e9c26fee598b541
-    subdirs:
-      - byron/semantics/executable-spec # small-steps
-      - byron/ledger/executable-spec    # cs-ledger
-      - byron/chain/executable-spec     # cs-blockchain
-
-  - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 3ac22a2fda11ca7131a011a9ea48fcbfdc26d6b3
-    subdirs:
-      - .
-      - test
-
-  - git: https://github.com/input-output-hk/goblins
-    commit: 26d35ad52fe9ade3391532dbfeb2f416f07650bc
-
-  - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 10877fbae54aa7a4c04ae3b5d87c825a4019e9e9
-    subdirs:
-      - contra-tracer
-  # --------------------------------------- cardano-ledger #

--- a/test/Data/UTxO/Transaction/Cardano/ByronSpec.hs
+++ b/test/Data/UTxO/Transaction/Cardano/ByronSpec.hs
@@ -14,6 +14,8 @@ import Cardano.Chain.UTxO
     ( TxIn (..), TxInWitness (..), TxOut (..), TxSigData (..) )
 import Cardano.Crypto.ProtocolMagic
     ( ProtocolMagicId (..) )
+import Control.Monad
+    ( foldM )
 import Data.ByteString
     ( ByteString )
 import Data.Function
@@ -33,6 +35,7 @@ import Data.UTxO.Transaction.Cardano.Byron
     , encodeTx
     , fromBase16
     , fromBase58
+    , fromBase64
     , mainnetMagic
     , mkInit
     , mkInput
@@ -40,6 +43,8 @@ import Data.UTxO.Transaction.Cardano.Byron
     , mkSignKey
     , testnetMagic
     )
+import System.Process
+    ( readProcess )
 import Test.Cardano.Chain.UTxO.Gen
     ( genTxIn, genTxInWitness, genTxOut, genTxSigData )
 import Test.Hspec
@@ -53,13 +58,12 @@ import Test.QuickCheck
     , elements
     , listOf
     , property
+    , quickCheck
     , withMaxSuccess
     , (===)
     )
 import Test.QuickCheck.Hedgehog
     ( hedgehog )
-import Test.QuickCheck.Monadic
-    ( monadicIO, run )
 
 import qualified Codec.CBOR.Decoding as CBOR
 import qualified Codec.CBOR.Encoding as CBOR
@@ -68,7 +72,10 @@ import qualified Codec.CBOR.Read as CBOR
 import qualified Codec.CBOR.Write as CBOR
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.List.NonEmpty as NE
+import qualified Data.Text as T
 import qualified Data.UTxO.Transaction as Tx
+
+{-# ANN spec ("HLint: ignore Use head" :: String) #-}
 
 spec :: Spec
 spec = do
@@ -80,16 +87,11 @@ spec = do
             prop_RoundTripCBOR encodeTx decodeTx
 
     describe "(Mainnet) Golden Tests Transaction Construction" $ do
-        let Just out0 = mkOutput 42 $ unsafeB58
-                "Ae2tdPwUPEZETXfbQxKMkMJQY1MoHCBS7bkw6TmhLjRvi9LZh1uDnXy319f"
+        let Just out0 = mkOutput 42 $ unsafeB58 (addrs !! 0)
+        let Just out1 = mkOutput 14 $ unsafeB58 (addrs !! 1)
+        let Just out2 = mkOutput 14 $ unsafeB58 (addrs !! 0)
 
-        let Just out1 = mkOutput 14 $ unsafeB58
-                "Ae2tdPwUPEZ69HTPqLpnFFw2MAfwdEoV5cpVQP5Uy1bPijSEHQmMXUfT3q5"
-
-        let Just out2 = mkOutput 14 $ unsafeB58
-                "Ae2tdPwUPEZETXfbQxKMkMJQY1MoHCBS7bkw6TmhLjRvi9LZh1uDnXy319f"
-
-        it "1 input, 1 output" $ do
+        it "1 input, 1 output (DSL)" $ do
             compareGolden goldenMainnet__1_1 $ Tx.empty mainnetMagic
                 & Tx.addInput inp0
                 & Tx.addOutput out0
@@ -97,7 +99,16 @@ spec = do
                 & Tx.signWith key0
                 & Tx.serialize
 
-        it "2 inputs, 2 outputs" $ do
+        it "1 input, 1 output (CLI)" $ do
+            compareGolden goldenMainnet__1_1 . fromBase64E =<< (
+                  cardanoTx [ "empty", mainnetMagicT ] ""
+              >>= cardanoTx [ "add-input", "0", txids !! 0 ]
+              >>= cardanoTx [ "add-output", "42", addrs !! 0 ]
+              >>= cardanoTx [ "lock" ]
+              >>= cardanoTx [ "sign-with", keys !! 0 ]
+              >>= cardanoTx [ "serialize" ])
+
+        it "2 inputs, 2 outputs (DSL)" $ do
             compareGolden goldenMainnet__2_2 $ Tx.empty mainnetMagic
                 & Tx.addInput inp0
                 & Tx.addInput inp1
@@ -108,7 +119,19 @@ spec = do
                 & Tx.signWith key1
                 & Tx.serialize
 
-        it "1 input, 25 outputs" $ do
+        it "2 inputs, 2 outputs (CLI)" $ do
+            compareGolden goldenMainnet__2_2 . fromBase64E =<< (
+                  cardanoTx [ "empty", mainnetMagicT ] ""
+              >>= cardanoTx [ "add-input", "0", txids !! 0 ]
+              >>= cardanoTx [ "add-input", "1", txids !! 0 ]
+              >>= cardanoTx [ "add-output", "42", addrs !! 0 ]
+              >>= cardanoTx [ "add-output", "14", addrs !! 1 ]
+              >>= cardanoTx [ "lock" ]
+              >>= cardanoTx [ "sign-with", keys !! 0 ]
+              >>= cardanoTx [ "sign-with", keys !! 1 ]
+              >>= cardanoTx [ "serialize" ])
+
+        it "1 input, 25 outputs (DSL)" $ do
             compareGolden goldenMainnet__25_1 $ Tx.empty mainnetMagic
                 & Tx.addInput inp0
                 & flip (foldr Tx.addOutput) (replicate 25 out2)
@@ -116,17 +139,21 @@ spec = do
                 & Tx.signWith key0
                 & Tx.serialize
 
+        it "1 input, 25 outputs (CLI)" $ do
+            compareGolden goldenMainnet__25_1 . fromBase64E =<< (
+                  cardanoTx [ "empty", mainnetMagicT ] ""
+              >>= cardanoTx [ "add-input", "0", txids !! 0 ]
+              >>= flip (foldM (&)) (replicate 25 $ cardanoTx [ "add-output", "14", addrs !! 0])
+              >>= cardanoTx [ "lock" ]
+              >>= cardanoTx [ "sign-with", keys !! 0 ]
+              >>= cardanoTx [ "serialize" ])
+
     describe "(Testnet) Golden Tests Transaction Construction" $ do
-        let Just out0 = mkOutput 42 $ unsafeB58
-                "2cWKMJemoBajc46Wu4Z7e6bG48myZWfB7Z6pD77L6PrJQWt9HZ3Yv7o8CYZTBMqHTPTkv"
+        let Just out0 = mkOutput 42 $ unsafeB58 (addrs !! 2)
+        let Just out1 = mkOutput 14 $ unsafeB58 (addrs !! 3)
+        let Just out2 = mkOutput 14 $ unsafeB58 (addrs !! 2)
 
-        let Just out1 = mkOutput 14 $ unsafeB58
-                "2cWKMJemoBaiLiNB8QpHKjkQhnPdQSyxaLb8JJFUQYpiVzgEJE59fN7V7StqnyDuDjHYJ"
-
-        let Just out2 = mkOutput 14 $ unsafeB58
-                "2cWKMJemoBajc46Wu4Z7e6bG48myZWfB7Z6pD77L6PrJQWt9HZ3Yv7o8CYZTBMqHTPTkv"
-
-        it "1 input, 1 output" $ do
+        it "1 input, 1 output (DSL)" $ do
             compareGolden goldenTestnet__1_1 $ Tx.empty testnetMagic
                 & Tx.addInput inp0
                 & Tx.addOutput out0
@@ -134,7 +161,16 @@ spec = do
                 & Tx.signWith key0
                 & Tx.serialize
 
-        it "2 inputs, 2 outputs" $ do
+        it "1 input, 1 output (CLI)" $ do
+            compareGolden goldenTestnet__1_1 . fromBase64E =<< (
+                  cardanoTx [ "empty", testnetMagicT ] ""
+              >>= cardanoTx [ "add-input", "0", txids !! 0 ]
+              >>= cardanoTx [ "add-output", "42", addrs !! 2 ]
+              >>= cardanoTx [ "lock" ]
+              >>= cardanoTx [ "sign-with", keys !! 0 ]
+              >>= cardanoTx [ "serialize" ])
+
+        it "2 inputs, 2 outputs (DSL)" $ do
             compareGolden goldenTestnet__2_2 $ Tx.empty testnetMagic
                 & Tx.addInput inp0
                 & Tx.addInput inp1
@@ -145,29 +181,40 @@ spec = do
                 & Tx.signWith key1
                 & Tx.serialize
 
-        it "1 input, 25 outputs" $ do
+        it "2 inputs, 2 outputs (CLI)" $ do
+            compareGolden goldenTestnet__2_2 . fromBase64E =<< (
+                  cardanoTx [ "empty", testnetMagicT ] ""
+              >>= cardanoTx [ "add-input", "0", txids !! 0 ]
+              >>= cardanoTx [ "add-input", "1", txids !! 0 ]
+              >>= cardanoTx [ "add-output", "42", addrs !! 2 ]
+              >>= cardanoTx [ "add-output", "14", addrs !! 3 ]
+              >>= cardanoTx [ "lock" ]
+              >>= cardanoTx [ "sign-with", keys !! 0 ]
+              >>= cardanoTx [ "sign-with", keys !! 1 ]
+              >>= cardanoTx [ "serialize" ])
+
+        it "1 input, 25 outputs (DSL)" $ do
             compareGolden goldenTestnet__25_1 $ Tx.empty testnetMagic
                 & Tx.addInput inp0
                 & flip (foldr Tx.addOutput) (replicate 25 out2)
                 & Tx.lock
                 & Tx.signWith key0
                 & Tx.serialize
+
+        it "1 input, 25 outputs (CLI)" $ do
+            compareGolden goldenTestnet__25_1 . fromBase64E =<< (
+                  cardanoTx [ "empty", testnetMagicT ] ""
+              >>= cardanoTx [ "add-input", "0", txids !! 0 ]
+              >>= flip (foldM (&)) (replicate 25 $ cardanoTx [ "add-output", "14", addrs !! 2 ])
+              >>= cardanoTx [ "lock" ]
+              >>= cardanoTx [ "sign-with", keys !! 0 ]
+              >>= cardanoTx [ "serialize" ])
+
   where
-    Just inp0 = mkInput 0 $ unsafeB16
-        "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7"
-
-    Just inp1 = mkInput 1 $ unsafeB16
-        "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7"
-
-    Just key0 = mkSignKey $ unsafeB16
-        "e0860dab46f13e74ab834142e8877b80bf22044cae8ebab7a21ed1b8dc00c155\
-        \f6b78eee2a5bbd453ce7e7711b2964abb6a36837e475271f18ff36ae5fc8af73\
-        \e25db39fb78e74d4b53fb51776d0f5eb360e62d09b853f3a87ac25bf834ee1fb"
-
-    Just key1 = mkSignKey $ unsafeB16
-        "00bc08703e4bb4d9fe6edf4ad2ccb1ffc6fb8d555d96805d643e5d06afde605c\
-        \e7d41d056def11417b17d3fb7415392b5f329877f372e55b0959c71b2bd2b447\
-        \1bbf1c6081545b1ab140578d7b5c035bf904d05dd8e9b79b34d3160f86206bfc"
+    Just inp0 = mkInput 0 $ unsafeB16 (txids !! 0)
+    Just inp1 = mkInput 1 $ unsafeB16 (txids !! 0)
+    Just key0 = mkSignKey $ unsafeB16 (keys  !! 0)
+    Just key1 = mkSignKey $ unsafeB16 (keys  !! 1)
 
 --
 -- Property: Roundtrip CBOR
@@ -224,9 +271,9 @@ compareGolden
         -- ^ An expected encoded result
     -> Either e ByteString
         -- ^ The actual string received
-    -> Property
-compareGolden _want (Left e)   = monadicIO $ run $ expectationFailure (show e)
-compareGolden want (Right got) =
+    -> IO ()
+compareGolden _want (Left e)   = expectationFailure (show e)
+compareGolden want (Right got) = quickCheck $ withMaxSuccess 1 $
     -- NOTE Using QuickCheck here simply for getting better counter examples
     -- than HSpec in case of failure...
     conjoin (uncurry (===) <$> zip (lines prettyWant) (lines prettyGot))
@@ -250,9 +297,56 @@ unsafeB58 :: Text -> ByteString
 unsafeB58 = fromMaybe (error msg) . fromBase58
   where msg = "unable to decode base58 string."
 
+fromBase64E :: Text -> Either String ByteString
+fromBase64E = maybe (Left msg) Right . fromBase64
+  where msg = "unable to decode base64 string."
+
+mainnetMagicT :: Text
+mainnetMagicT = T.pack $ show $ unProtocolMagicId mainnetMagic
+
+testnetMagicT :: Text
+testnetMagicT = T.pack $ show $ unProtocolMagicId testnetMagic
+
+cardanoTx
+    :: [Text]
+        -- ^ Arguments
+    -> Text
+        -- ^ stdin
+    -> IO Text
+        -- ^ stdout
+cardanoTx args =
+    fmap T.pack . readProcess "cardano-tx" (T.unpack <$> args) . T.unpack
+
 --
 -- Test Vectors
 --
+
+txids :: [Text]
+txids =
+    [ "3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7"
+    ]
+
+addrs :: [Text]
+addrs =
+    -- Mainnet
+    [ "Ae2tdPwUPEZETXfbQxKMkMJQY1MoHCBS7bkw6TmhLjRvi9LZh1uDnXy319f"
+    , "Ae2tdPwUPEZ69HTPqLpnFFw2MAfwdEoV5cpVQP5Uy1bPijSEHQmMXUfT3q5"
+
+    -- Testnet
+    , "2cWKMJemoBajc46Wu4Z7e6bG48myZWfB7Z6pD77L6PrJQWt9HZ3Yv7o8CYZTBMqHTPTkv"
+    , "2cWKMJemoBaiLiNB8QpHKjkQhnPdQSyxaLb8JJFUQYpiVzgEJE59fN7V7StqnyDuDjHYJ"
+    ]
+
+keys :: [Text]
+keys =
+    [ "e0860dab46f13e74ab834142e8877b80bf22044cae8ebab7a21ed1b8dc00c155\
+      \f6b78eee2a5bbd453ce7e7711b2964abb6a36837e475271f18ff36ae5fc8af73\
+      \e25db39fb78e74d4b53fb51776d0f5eb360e62d09b853f3a87ac25bf834ee1fb"
+
+    , "00bc08703e4bb4d9fe6edf4ad2ccb1ffc6fb8d555d96805d643e5d06afde605c\
+      \e7d41d056def11417b17d3fb7415392b5f329877f372e55b0959c71b2bd2b447\
+      \1bbf1c6081545b1ab140578d7b5c035bf904d05dd8e9b79b34d3160f86206bfc"
+    ]
 
 goldenMainnet__1_1 :: ByteString
 goldenMainnet__1_1 = unsafeB16


### PR DESCRIPTION
- 92fc325385d259be41944626457649a6b1adbfc6
  :round_pushpin: **add command-line interface for using the DSL**
    ```
  $ cardano-tx --help
  Usage: cardano-tx COMMAND
    cardano-tx

  Available options:
    -h,--help                Show this help text

  Available commands:
    empty
    add-input                Add a new input to the transaction.
    add-output               Add a new output to the transaction.
    lock                     Lock the transaction and start signing inputs.
    sign-with                Add a signature.
    serialize                Serialize the signed transaction to binary.
  ```

- 7fefb65ae4474fccd08053ddffc9d4f187ab4797
  :round_pushpin: **mimic golden tests using the command-line**
  
- df915a15e61faa609c3669e04342e886e52932b3
  :round_pushpin: **add some negative tests testing missing input, output or signature**


# Comments

I will add unit tests that constructs the same transactions as in the golden tests and verify the output. 
But already, from manual testing:

```
cardano-tx empty 764824073 \
  | cardano-tx add-input 0 3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7 \
  | cardano-tx add-output 42 Ae2tdPwUPEZETXfbQxKMkMJQY1MoHCBS7bkw6TmhLjRvi9LZh1uDnXy319f \
  | cardano-tx lock \
  | cardano-tx sign-with e0860dab46f13e74ab834142e8877b80bf22044cae8ebab7a21ed1b8dc00c155f6b78eee2a5bbd453ce7e7711b2964abb6a36837e475271f18ff36ae5fc8af73e25db39fb78e74d4b53fb51776d0f5eb360e62d09b853f3a87ac25bf834ee1fb \
  | cardano-tx serialize

# goOfggDYGFgkglggO0AmURHYuzw8YI2Vs6C/g0YazjLXkzZXmhk5s6rRwLcA/5+CgtgYWCGDWByw5pPLyXJyvUKqzztEPsrGi5a0+iAVkYako4iDoAAaSXwVxhgq/6CBggDYGFiFglhAjmICNbKkJyWcwaHGOvnvF5yztuOW2hguAdZd0+176UviXbOft4501LU/tRd20PXrNg5i0JuFPzqHrCW/g07h+1hANoRQGiE0a6PBmm3DR5GA6AoU5e3A/7SxRpq+AzLn4crykdUMuNLEfuN/a0S3+/zFobAbwmIDjpOWm5pyiis1AA==
```

:tada: 

coverage from hpc:

```
 90% expressions used (270/299)   
 42% boolean coverage (3/7)       
      42% guards (3/7), 3 always True, 1 always False
     100% 'if' conditions (0/0)   
     100% qualifiers (0/0)        
 67% alternatives used (19/28)    
100% local declarations used (7/7)
 88% top-level declarations used (22/25)
```