### PR TITLE
UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 This library provides a simple interface for building transactions on Cardano. It also
 provides a small command-line interface for playing around in a terminal.
 
-## Byron
+## Payment
 
-For _Byron_, the library exposes an interface for constructing simple UTxO transactions (a.k.a _Payment_).
+We call _Payment_ a simple UTxO transactions with no metadata, moving funds from a set of inputs to a set of outputs.
 
 Payments are constructed from a small set of primitives, following the given state-machine:
 
@@ -120,16 +120,11 @@ cardano-tx empty 764824073 \
   | cardano-tx serialize
 ```
 
-## Shelley
-
-:construction: coming soon :construction:
-
 ## About Library Dependencies
 
 This library requires quite a few exotic dependencies from the cardano realm which aren't
 necessarily on hackage nor stackage. The dependencies are listed in [stack.yaml](https://github.com/input-output-hk/cardano-transactions/blob/master/stack.yaml#L7-L33),
 make sure to also include those for importing `cardano-transactions`.
-
 
 <hr/>
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -62,7 +62,7 @@ import Options.Applicative
     , subparser
     )
 import Options.Applicative.Help.Pretty
-    ( indent, string, vsep )
+    ( hardline, indent, string, vsep )
 import System.Console.ANSI
     ( Color (..)
     , ColorIntensity (..)
@@ -148,6 +148,46 @@ data Cmd
 
 cmd :: ParserInfo Cmd
 cmd = info (helper <*> cmds) $ progDesc "cardano-tx"
+    <> headerDoc (Just $ vsep
+        [ string "Construct and sign transactions according to the following state-machine:"
+        , hardline
+        , string "                           empty                    "
+        , string "                             |                      "
+        , string "      *------------------*   |   *-----------------*"
+        , string "      |                  |   |   |                 |"
+        , string "      |                  v   v   v                 |"
+        , string "      *--- add-output ---=========--- add-input ---*"
+        , string "                             |                      "
+        , string "                             |                      "
+        , string "                           lock   *----------------*"
+        , string "                             |    |                |"
+        , string "                             |    v                |"
+        , string "                         =========--- sign-with ---*"
+        , string "                             |                      "
+        , string "                             |                      "
+        , string "                         serialize                  "
+        , string "                             |                      "
+        , string "                             |                      "
+        , string "                             v                      "
+        , hardline
+        , string "/!\\ Except 'serialize', every command outputs an intermediate \
+            \state that is of little use and shouldn't be tempered with."
+        , string "Redirect the output to a file, or use Unix pipes as shown below."
+        ])
+    <> footerDoc (Just $ vsep
+        [ "Example:"
+        , indent 2 $ string "cardano-tx empty 764824073 \\"
+        , indent 2 $ string "  | cardano-tx add-input 0 \\"
+        , indent 2 $ string "      3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7 \\"
+        , indent 2 $ string "  | cardano-tx add-output 42 \\"
+        , indent 2 $ string "      Ae2tdPwUPEZETXfbQxKMkMJQY1MoHCBS7bkw6TmhLjRvi9LZh1uDnXy319f \\"
+        , indent 2 $ string "  | cardano-tx lock \\"
+        , indent 2 $ string "  | cardano-tx sign-with \\"
+        , indent 2 $ string "      e0860dab46f13e74ab834142e8877b80bf22044cae8ebab7a21ed1b8dc00c155 \\"
+        , indent 2 $ string "      f6b78eee2a5bbd453ce7e7711b2964abb6a36837e475271f18ff36ae5fc8af73 \\"
+        , indent 2 $ string "      e25db39fb78e74d4b53fb51776d0f5eb360e62d09b853f3a87ac25bf834ee1fb \\"
+        , indent 2 $ string "  | cardano-tx serialize"
+        ])
   where
     cmds = subparser $ mconcat
         [ cmdEmpty


### PR DESCRIPTION
- 4bc718418030eadea25ed86b0e8d7030985ef37e
  :round_pushpin: **Make a more user-friendly output for the intermediate CLI state**
    So that the output looks a bit less 'scary' if curious users peek into
  the intermediate construct. It looks also nicer to put in a temporary
  file and, allows for embedding metadata for future extensions.

  e.g.:
  ```
  $ cardano-tx empty 14 \
    | cardano-tx add-input 14 3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7 \
    | cardano-tx add-output 13371442 2cWKMJemoBajc46Wu4Z7e6bG48myZWfB7Z6pD77L6PrJQWt9HZ3Yv7o8CYZTBMqHTPTkv

  -----BEGIN CARDANO TX-----
  version: 1.0.0
  Dp+CANgYWCSCWCA7QCZREdi7PDxgjZWzoL+DRhrOMteTNleaGTmzqtHAtw7/n4KC
  2BhYKINYHJRkgOtF+pAOhNHyUUFYlGjKHTi7tObDq+x9HqChAkUaQXDLFwAaFrvg
  qxoAzAgy/w==
  -----END CARDANO TX-----

- 8bad60dc1cdee1889dce38e85868d274be6c33ce
  :round_pushpin: **slightly adjust README, replace Byron for 'Payment'**
  The interface will remain the same in Shelley for 'Payment', but there will be new types
of transactions

- 258a0488a336b7a859ed3cce962228096b79fb9a
  :round_pushpin: **Add more descriptive top-level help for cardano-tx**
    ```
  $ cardano-tx --help
  Construct and sign transactions according to the following state-machine:

                             empty
                               |
        *------------------*   |   *-----------------*
        |                  |   |   |                 |
        |                  v   v   v                 |
        *--- add-output ---=========--- add-input ---*
                               |
                               |
                             lock   *----------------*
                               |    |                |
                               |    v                |
                           =========--- sign-with ---*
                               |
                               |
                           serialize
                               |
                               |
                               v

  /!\ Except 'serialize', every command outputs an intermediate state that is of little use and shouldn't be tempered with.
  Redirect the output to a file, or use Unix pipes as shown below.

  Usage: cardano-tx COMMAND
    cardano-tx

  Available options:
    -h,--help                Show this help text

  Available commands:
    empty
    add-input                Add a new input to the transaction.
    add-output               Add a new output to the transaction.
    lock                     Lock the transaction and start signing inputs.
    sign-with                Add a signature.
    serialize                Serialize the signed transaction to binary.

  Example:
    cardano-tx empty 764824073 \
      | cardano-tx add-input 0 \
          3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7 \
      | cardano-tx add-output 42 \
          Ae2tdPwUPEZETXfbQxKMkMJQY1MoHCBS7bkw6TmhLjRvi9LZh1uDnXy319f \
      | cardano-tx lock \
      | cardano-tx sign-with \
          e0860dab46f13e74ab834142e8877b80bf22044cae8ebab7a21ed1b8dc00c155 \
          f6b78eee2a5bbd453ce7e7711b2964abb6a36837e475271f18ff36ae5fc8af73 \
          e25db39fb78e74d4b53fb51776d0f5eb360e62d09b853f3a87ac25bf834ee1fb \
      | cardano-tx serialize
  ```
