### PR TITLE
Link end-to-end cli example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ make sure to also include those for importing `cardano-transactions`.
 
 API documentation is available [here](https://input-output-hk.github.io/cardano-transactions/haddock).
 
+[End-to-end example](https://github.com/input-output-hk/cardano-transactions/wiki/How-to-submit-transaction-via-cardano-tx-CLI) of constructing transaction via `cardano-tx` and then submitting it.
+
 ## Contributing
 
 Pull requests are welcome.


### PR DESCRIPTION
Added link to [CLI example](https://github.com/input-output-hk/cardano-transactions/wiki/How-to-submit-transaction-via-cardano-tx-CLI) in the README's _Documentation_ section.