### PR TITLE
cardano-node: 1.20.0 -> 1.22.1

### DIFF
--- a/src/Data/UTxO/Transaction/Cardano/Shelley.hs
+++ b/src/Data/UTxO/Transaction/Cardano/Shelley.hs
@@ -41,12 +41,10 @@ import Cardano.Api.Typed
     , TxIn (..)
     , TxOut (..)
     )
-import Cardano.Binary
-    ( serialize' )
 import Cardano.Crypto.Extra
     ( xprvFromBytes )
 import Cardano.Crypto.Hash.Class
-    ( Hash (UnsafeHash), hashWith )
+    ( Hash (UnsafeHash) )
 import Cardano.Crypto.Signing
     ( SigningKey (..) )
 import Cardano.Slotting.Slot
@@ -66,6 +64,7 @@ import qualified Cardano.Api.Typed as Cardano
 import qualified Data.ByteString as BS
 import qualified Shelley.Spec.Ledger.Address.Bootstrap as Ledger
 import qualified Shelley.Spec.Ledger.Credential as Ledger
+import qualified Shelley.Spec.Ledger.TxBody as Ledger
 
 
 -- | A type isomorphic to 'Integer' to represent fees.
@@ -284,8 +283,8 @@ instance MkPayment Shelley where
       where
         byronWit = Cardano.ShelleyBootstrapWitness $
             Ledger.makeBootstrapWitness txHash skey attrs
-        (Cardano.ShelleyTxBody body _) = sigData
-        txHash = hashWith serialize' body
+        Cardano.ShelleyTxBody body _ = sigData
+        txHash = Ledger.eraIndTxBodyHash body
         attrs  = mkAttributes addrAttrs
 
     serialize :: Tx Shelley -> Either ErrMkPayment ByteString

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/cfe917f0f419b5c9f63c958f335874e4dc0add85/snapshots/cardano-1.20.0.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-haskell/905546b2901572577ff0a515e60a8f079c5bf1aa/snapshots/cardano-1.22.1.yaml
 
 # Generate files required by Weeder.
 # See https://github.com/ndmitchell/weeder/issues/53


### PR DESCRIPTION
### Overview

- [x] Updates Cardano libraries to latest release. See also input-output-hk/cardano-haskell#34.
- [x] Fix compile errors.

### Comments

The CI says style checks failed, but that's not right - PR #25 should hopefully fix it.

Build failure that was fixed:
```
Building library for cardano-transactions-1.0.0..
[6 of 7] Compiling Data.UTxO.Transaction.Cardano.Shelley ( src/Data/UTxO/Transaction/Cardano/Shelley.hs, .stack-work/dist/x86_64-linux/Cabal-2.4.0.1/build/Data/UTxO/Transaction/Cardano/Shelley.o )

/home/rodney/iohk/cardano-transactions/src/Data/UTxO/Transaction/Cardano/Shelley.hs:287:32: error:
    • Couldn't match expected type ‘Shelley.Spec.Ledger.Hashing.EraIndependentTxBody’
                  with actual type ‘Shelley.Spec.Ledger.TxBody.TxBody
                                      Cardano.StandardShelley’
    • In the pattern: Cardano.ShelleyTxBody body _
      In a pattern binding: (Cardano.ShelleyTxBody body _) = sigData
      In an equation for ‘signWith’:
          signWith
            (ByronSigningKey addrAttrs skey)
            (Right (net, inps, outs, sigData, wits))
            = Right (net, inps, outs, sigData, byronWit : wits)
            where
                byronWit
                  = Cardano.ShelleyBootstrapWitness
                      $ Ledger.makeBootstrapWitness txHash skey attrs
                (Cardano.ShelleyTxBody body _) = sigData
                txHash = hashWith serialize' body
                attrs = mkAttributes addrAttrs
    |
287 |         (Cardano.ShelleyTxBody body _) = sigData
    |                                ^^^^
```