### PR TITLE
Fix CI style check errors

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -21,7 +21,7 @@ jobs:
     - name: ✍  Check hlint and stylish
       run: |
         curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/run.sh | sh -s .
-        curl -sSL https://raw.github.com/jaspervdj/stylish-haskell/master/scripts/latest.sh | sh -s $(find . -type f -name "*.hs" ! -path "*.stack-work*") -i
+        curl -sSL https://raw.github.com/input-output-hk/adrestia/master/.haskell/stylish-haskell.sh | VERSION=v0.11.0.0 sh -s $(git ls-files '*.hs') -i
         if [ -z "$(git status --porcelain)" ]; then
             echo "No style errors detected."
         else


### PR DESCRIPTION
stylish-haskell in GitHub actions does not appear to use the config file in this repo.

This attempts to fix it by using v0.11.0.0.
